### PR TITLE
Add a makefile for the AOMP compiler

### DIFF
--- a/test/nek_gpu1/makefile.aomp
+++ b/test/nek_gpu1/makefile.aomp
@@ -1,0 +1,173 @@
+### makefile automatically created by makenek 03/30/2020 10:06:17 ###
+BINNAME=nekbone
+CASENAME:=
+CASEDIR:=~/git/aomp-test/Nekbone/test/nek_gpu1
+S:=~/git/aomp-test/Nekbone/src
+J:=$S/jl
+OPT_INCDIR:=./
+OBJDIR=obj
+IFMPI:=false
+IFNEKCOMM:=
+IFNEKDLAY:=
+IFMGRID:=
+F77:=flang
+CC:=clang
+P:=-r8 -i8 -cpp -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900
+PPPO=
+PPS= PTRSIZE8 LONGINT8 UNDERSCORE GLOBAL_LONG_LONG
+G:=-fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900
+OPT_FLAGS_STD=
+USR:=
+USR_LFLAGS:=-lm
+
+################################################################################
+
+lFLAGS = $(USR_LFLAGS)
+
+PPS_F = $(patsubst %,$(PPPO)-D%,$(PPS))
+PPS_C = $(patsubst %,-D%,$(PPS))
+
+#NEW #########################################################################
+BONE = cg.o driver.o math.o mxm_wrapper.o prox_dssum.o\
+prox_setup.o semhat.o speclib.o 
+
+ifeq ($(IFNEKCOMM),true)
+BONE = driver_comm.o math.o mxm_wrapper.o \
+speclib.o delay_dum.o
+else
+ifeq ($(IFNEKDLAY),true)
+BONE += delay.o
+else
+BONE += delay_dum.o
+endif
+endif
+
+ifeq ($(IFMGRID),true)
+BONE += hsmg.o dsygv.o ssygv.o
+else
+BONE += hsmg_dum.o
+endif
+################################################################################
+# MXM 
+MXM=mxm_std.o blas.o
+
+################################################################################
+# CUDA
+BONE += ax_cuda.o 
+
+# JL Routines ###################################################################
+JO  = jl_
+JL := -DPREFIX=jl_
+
+JLCORE = $(JO)gs.o $(JO)sort.o $(JO)sarray_transfer.o $(JO)sarray_sort.o \
+$(JO)gs_local.o $(JO)crystal.o $(JO)comm.o $(JO)tensor.o $(JO)fail.o \
+$(JO)fcrystal.o $(JO)sleep.o
+
+COMM_MPI := comm_mpi.o
+ifeq ($(IFMPI),false)
+  COMM_MPI := ${COMM_MPI} mpi_dummy.o
+endif
+
+ifeq ($(IFMPI),false)
+	DUMMY:= $(shell cp $S/mpi_dummy.h $S/mpif.h) 
+else
+	DUMMY:= $(shell rm -rf $S/mpif.h) 
+endif
+
+#####################################################################################
+TMPBON = $(BONE) $(COMM_MPI) $(MXM)
+NOBJS_Fbon = $(patsubst %,$(OBJDIR)/%,$(TMPBON))
+
+TMP0c = $(JLCORE)
+NOBJS_C0 = $(patsubst %,$(OBJDIR)/%,$(TMP0c))
+
+NOBJS0_bone = $(NOBJS_Fbon) $(NOBJS_C0)
+##############################################################################
+
+L0=$(G) -O0
+L2=$(G) -O3
+L3=$(G) -O3
+L4=$(L3)
+
+FL0   = $(L0) $(P) $(PPS_F) -I$(CASEDIR) -I$S -I$(OPT_INCDIR)
+FL2i4 = $(L0)      $(PPS_F) -I$(CASEDIR) -I$S -I$(OPT_INCDIR)
+FL2   = $(L2) $(P) $(PPS_F) -I$(CASEDIR) -I$S -I$(OPT_INCDIR)
+FL3   = $(L3) $(P) $(PPS_F) -I$(CASEDIR) -I$S -I$(OPT_INCDIR)
+FL4   = $(L4) $(P) $(PPS_F) -I$(CASEDIR) -I$S -I$(OPT_INCDIR)
+
+cFL0   = $(L0) $(PPS_C) -g
+cFL2   = $(L2) $(PPS_C) -g
+cFL3   = $(L3) $(PPS_C) -g
+cFL4   = $(L4) $(PPS_C) -g
+################################################################################
+all : nekbone
+
+objdir: 
+	@mkdir $(OBJDIR) 2>/dev/null; cat /dev/null 
+
+nekbone: 	objdir $(NOBJS0_bone)
+	$(F77) -o ${BINNAME} $G $(NOBJS0_bone) $(lFLAGS)
+	@if test -f ${BINNAME}; then \
+	echo "#############################################################"; \
+	echo "#                  Compilation successful!                  #"; \
+	echo "#############################################################"; \
+        size ${BINNAME}; \
+        echo ""; \
+	else \
+	echo -e "\033[1;31;38m" "ERROR: Compilation failed!"; \
+	echo -e "\033[0m"; \
+	fi
+ifeq ($(IFMPI),false) 
+	@rm -rf $S/mpif.h
+endif
+
+clean:
+	rm -rf $(OBJDIR) ${BINNAME}
+
+$(NOBJS_Fbon) : SIZE
+# CORE      ############################################################################
+$(OBJDIR)/cg.o          :$S/cg.f;                       $(F77) -c $(FL4) $< -o $@
+$(OBJDIR)/prox_dssum.o  :$S/prox_dssum.f;               $(F77) -c $(FL2) $< -o $@
+$(OBJDIR)/prox_setup.o  :$S/prox_setup.f;               $(F77) -c $(FL4) $< -o $@
+$(OBJDIR)/hsmg.o        :$S/hsmg.f;                     $(F77) -c $(FL2) $< -o $@
+$(OBJDIR)/hsmg_dum.o    :$S/hsmg_dum.f;                 $(F77) -c $(FL2) $< -o $@
+$(OBJDIR)/ssygv.o       :$S/ssygv.f;                    $(F77) -c $(FL2i4) $< -o $@
+$(OBJDIR)/dsygv.o       :$S/dsygv.f;                    $(F77) -c $(FL2i4) $< -o $@
+$(OBJDIR)/driver.o      :$S/driver.f;                   $(F77) -c $(FL2) $< -o $@
+$(OBJDIR)/driver_comm.o	:$S/driver_comm.f;		$(F77) -c $(FL2) $< -o $@
+$(OBJDIR)/math.o	:$S/math.f;			$(F77) -c $(FL4) $< -o $@
+$(OBJDIR)/semhat.o	:$S/semhat.f;			$(F77) -c $(FL4) $< -o $@
+$(OBJDIR)/speclib.o	:$S/speclib.f;			$(F77) -c $(FL2) $< -o $@
+$(OBJDIR)/blas.o        :$S/blas.f; 		        $(F77) -c $(FL2i4) $< -o $@
+$(OBJDIR)/comm_mpi.o	:$S/comm_mpi.f;			$(F77) -c $(FL2) $< -o $@
+$(OBJDIR)/mpi_dummy.o	:$S/mpi_dummy.f;		$(F77) -c $(FL2) $< -o $@
+$(OBJDIR)/delay.o	:$S/delay.f;			$(F77) -c $(FL2) $< -o $@
+$(OBJDIR)/delay_dum.o	:$S/delay_dum.f;		$(F77) -c $(FL2) $< -o $@
+# MXM       ############################################################################
+$(OBJDIR)/mxm_wrapper.o	  :$S/mxm_wrapper.f;		$(F77) -c $(FL2) $< -o $@ 
+$(OBJDIR)/mxm_std.o	  :$S/mxm_std.f;		$(F77) -c $(FL4) $< -o $@
+$(OBJDIR)/bg_aligned3.o	  :$S/bg_aligned3.s;		$(CC) -c $< -o $@
+$(OBJDIR)/bg_mxm3.o	  :$S/bg_mxm3.s;		$(CC) -c $< -o $@
+$(OBJDIR)/bg_mxm44.o	  :$S/bg_mxm44.s;		$(CC) -c $< -o $@
+$(OBJDIR)/bg_mxm44_uneven.o :$S/bg_mxm44_uneven.s;	$(CC) -c $< -o $@
+$(OBJDIR)/k10_mxm.o	  :$S/k10_mxm.c;		$(CC)  -c $(cFL2) $(JL) $< -o $@
+# C Files ##################################################################################
+$(OBJDIR)/byte.o                 :$S/byte.c;              $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/chelpers.o             :$S/chelpers.c;          $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)fail.o            :$(J)/fail.c;            $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)tensor.o          :$(J)/tensor.c;          $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)sort.o            :$(J)/sort.c;            $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)sarray_sort.o     :$(J)/sarray_sort.c;     $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)comm.o            :$(J)/comm.c;            $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)crystal.o         :$(J)/crystal.c;         $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)sarray_transfer.o :$(J)/sarray_transfer.c; $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)fcrystal.o        :$(J)/fcrystal.c;        $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)sleep.o		:$(J)/sleep.c;		$(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)gs.o              :$(J)/gs.c;              $(CC) -c $(cFL2) $(JL) $< -o $@
+$(OBJDIR)/$(JO)gs_local.o        :$(J)/gs_local.c;        $(CC) -c $(cFL2) $(JL) $< -o $@
+
+# OPENACC #########################################################################################
+$(OBJDIR)/ax_acc.o  :$S/ax_acc.f;   $(F77) -c $(FL3) $< -o $@
+
+# CUDA ############################################################################################
+$(OBJDIR)/ax_cuda.o   :$S/ax_cuda.f;  $(F77) -c $(FL3) $< -o $@


### PR DESCRIPTION
You don't need to run the makefile generator.  Simply `make -f makefile.aomp`.

@ronlieb @pbauman Does this look okay?