### PR TITLE
Add flang support to makefile generator

### DIFF
--- a/src/makenek.inc
+++ b/src/makenek.inc
@@ -154,6 +154,8 @@ fi
 case $F77comp in
   *pgf*)        P="-r8 -Mpreprocess -Mfixed"
                ;;
+  *flang*)      P="-r8 -i8 -cpp -Mfixed"
+               ;;
   *gfortran*)   P="-fdefault-real-8 -cpp -ffixed-form"
                ;;
   *ifort*)      P="-r8 -fpconstant -fpp -fixed"


### PR DESCRIPTION
I know @ronlieb added an AOMP-specific makefile already in #2.  This patch just adds flang support directly into the makefile generator.