### PR TITLE
Ensure opt pass does not default to -O0.

### DIFF
--- a/test/nek_gpu1/makefile.aomp
+++ b/test/nek_gpu1/makefile.aomp
@@ -106,7 +106,7 @@ objdir:
 	@mkdir $(OBJDIR) 2>/dev/null; cat /dev/null 
 
 nekbone: 	objdir $(NOBJS0_bone)
-	$(F77) -o ${BINNAME} $G $(NOBJS0_bone) $(lFLAGS)
+	$(F77) -O3 -o ${BINNAME} $G $(NOBJS0_bone) $(lFLAGS)
 	@if test -f ${BINNAME}; then \
 	echo "#############################################################"; \
 	echo "#                  Compilation successful!                  #"; \


### PR DESCRIPTION
At O0 the needs_hostcall_buffer symbol is not optimized
out and results in poor performance.