### PR TITLE
Add -fdisable-host-devmem to makefile.aomp

### DIFF
--- a/test/nek_gpu1/makefile.aomp
+++ b/test/nek_gpu1/makefile.aomp
@@ -106,7 +106,7 @@ objdir:
 	@mkdir $(OBJDIR) 2>/dev/null; cat /dev/null 
 
 nekbone: 	objdir $(NOBJS0_bone)
-	$(F77) -O3 -o ${BINNAME} $G $(NOBJS0_bone) $(lFLAGS)
+	$(F77) -O3 -fdisable-host-devmem -o ${BINNAME} $G $(NOBJS0_bone) $(lFLAGS)
 	@if test -f ${BINNAME}; then \
 	echo "#############################################################"; \
 	echo "#                  Compilation successful!                  #"; \


### PR DESCRIPTION
This is currently enabled by default with the new OpenMP
DeviceRTL and is hurting Nekbone performance.